### PR TITLE
161 merge httpsgithubcomclamsprojectapp nlp example 1

### DIFF
--- a/docs/clamsapp.md
+++ b/docs/clamsapp.md
@@ -8,7 +8,7 @@ hence it's advised also to look up the app website (or code repository) to get t
 
 Generally, a CLAMS App requires 
 
-- To run the app locally, Python3 with the `clams-python` module installed. Python 3.6 or higher is required.
+- To run the app locally, Python3 with the `clams-python` module installed. Python 3.8 or higher is required.
 - To run the app in a container (as an HTTP server), container management software such as `docker` or `podman`.
   - (the CLAMS team is using `docker` for development and testing)
 - To invoke and execute analysis, HTTP client utility (such as `curl`).


### PR DESCRIPTION
Migrating documentation from https://github.com/clamsproject/app-nlp-example in accordance with [this issue](https://github.com/clamsproject/clams-python/issues/161)