### PR TITLE
jekyll workflows

### DIFF
--- a/.github/workflows/jekyll-build-deploy.yml
+++ b/.github/workflows/jekyll-build-deploy.yml
@@ -1,0 +1,59 @@
+name: Build Jekyll Site
+on:
+  workflow_call:
+    inputs: 
+      branch-name:
+        required: true
+        type: string
+    secrets:
+      USER_TOKEN:
+        required: true
+
+  workflow_dispatch:
+    inputs:
+      branch-name:
+        required: true
+        type: string
+
+permissions: 
+  contents: read
+  pages: write
+  id-token: write 
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+
+      - run: echo "building from ${{inputs.branch-name}}"
+
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Setup Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3.1.2'
+          bundler-cache: true
+
+      - name: Setup Pages
+        uses: actions/configure-pages@v3
+          
+      - name: Build Site
+        run: bundle exec jekyll build --baseurl "${{ steps.pages.outputs.base_path }}"
+        env:
+          JEKYLL_ENV: production
+
+      - name: Upload Artifact
+        uses: actions/upload-pages-artifact@v1
+        
+  deploy:
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v2
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}


### PR DESCRIPTION
identical to main branch, except that it includes a new `jekyll-build-deploy.yml` workflow, which is intended to be called by other workflows (such as the ones in `clams-python` ) in order to refresh the site.